### PR TITLE
Add bluetooth adapters dependency

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Divoom",
   "documentation": "https://github.com/d03n3rfr1tz3/hass-divoom/blob/master/README.md",
   "requirements": [ "pillow>=7.2.0" ],
-  "dependencies": [],
+  "dependencies": [ "bluetooth_adapters" ],
   "codeowners": ["@d03n3rfr1tz3"],
   "iot_class": "local_push",
   "version": "1.0.0"


### PR DESCRIPTION
For the custom component to work on Raspberry Pi, you have to add the "bluetooth_adapters" dependency to the manifest, so that the component will be loaded after bluetooth initialization.

See https://developers.home-assistant.io/docs/bluetooth/ for details