### PR TITLE
"set sleep auto off"

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,12 +540,13 @@ Enabled or disables the sleep mode, which plays soothing sounds, optionally with
 
 | Parameter    | Description |
 | ---          | ---         |
-| `time`       | The time after which to stop the sleep mode. Defaults to `120` when not provided. |
+| `brightness` | The brightness value between 0 and 100. |
+| `color`      | The color of the clock. Accepts an array of RGB color values. |
+| `frequency`  | The radio frequency to set. |
 | `sleepmode`  | The sound effect to play. Check in the app how many options are available. Accepts a number. |
+| `time`       | The time after which to stop the sleep mode. Defaults to `120` when not provided. |
 | `value`      | Controls the start/stop state. <br/> `0` = stop, `1` = start |
 | `volume`     | The volume value between 0 and 100. |
-| `color`      | The color of the clock. Accepts an array of RGB color values. Only relevant when `sleeptime` is set. |
-| `brightness` | The brightness value between 0 and 100. Only relevant when `sleeptime` is set. |
 
 ```
 message: 'sleep'

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Enabled or disables the sleep mode, which plays soothing sounds, optionally with
 
 | Parameter    | Description |
 | ---          | ---         |
-| `sleeptime`  | The time after which to stop the sleepmode. When provided the device lights up. |
+| `time`       | The time after which to stop the sleep mode. Defaults to `120` when not provided. |
 | `sleepmode`  | The sound effect to play. Check in the app how many options are available. Accepts a number. |
 | `value`      | Controls the start/stop state. <br/> `0` = stop, `1` = start |
 | `volume`     | The volume value between 0 and 100. |
@@ -550,7 +550,7 @@ Enabled or disables the sleep mode, which plays soothing sounds, optionally with
 ```
 message: 'sleep'
 data:
-  sleeptime: 30
+  time: 30
   sleepmode: 4
   value: 1
   volume: 10

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ a Notification Service. Just send controls/animations to your Divoom device thro
       - [MODE radio](#mode-radio)
       - [MODE raw](#mode-raw)
       - [MODE scoreboard](#mode-scoreboard)
+      - [MODE sleep](#mode-sleep)
       - [MODE timer](#mode-timer)
       - [MODE visualization](#mode-visualization)
       - [MODE volume](#mode-volume)
@@ -532,6 +533,29 @@ message: 'scoreboard'
 data:
   player1: 2
   player2: 1
+```
+
+#### MODE sleep
+Enabled or disables the sleep mode, which plays soothing sounds, optionally with a timer and light.
+
+| Parameter    | Description |
+| ---          | ---         |
+| `sleeptime`  | The time after which to stop the sleepmode. When provided the device lights up. |
+| `sleepmode`  | The sound effect to play. Check in the app how many options are available. Accepts a number. |
+| `value`      | Controls the start/stop state. <br/> `0` = stop, `1` = start |
+| `volume`     | The volume value between 0 and 100. |
+| `color`      | The color of the clock. Accepts an array of RGB color values. Only relevant when `sleeptime` is set. |
+| `brightness` | The brightness value between 0 and 100. Only relevant when `sleeptime` is set. |
+
+```
+message: 'sleep'
+data:
+  sleeptime: 30
+  sleepmode: 4
+  value: 1
+  volume: 10
+  color: [255, 255, 0]
+  brightness: 50
 ```
 
 #### MODE timer

--- a/custom_components/divoom/devices/divoom.py
+++ b/custom_components/divoom/devices/divoom.py
@@ -30,7 +30,6 @@ class Divoom:
         "set game keypress": 0x88,
         "set game": 0xa0,
         "set design": 0xbd,
-        "set sleep": 0xa3,
         "set sleeptime": 0x40,
     }
 
@@ -684,32 +683,25 @@ class Divoom:
 
     def sleep(self, value=None, mode=None, volume=None, time=None, color=None, brightness=None):
         """Set sleep mode on the Divoom device and optionally sets mode, volume, time, color, and brightness"""
+        if time is None: time = 120
         if mode is None: mode = 0
         sleep_value = 0x01 if value else 0x00
         if volume is None: volume = 100
         if brightness is None: brightness = 100
 
-        if time is None:
-            args = []
-            args += sleep_value.to_bytes(1, byteorder='big')
-            args += mode.to_bytes(1, byteorder='big')
-            args += volume.to_bytes(1, byteorder='big')
-
-            result = self.send_command("set sleep", args)
+        args = []
+        args += time.to_bytes(1, byteorder='big')
+        args += mode.to_bytes(1, byteorder='big')
+        args += sleep_value.to_bytes(1, byteorder='big')
+        args += b'\x00\x00'  # nil FM frequency values
+        args += volume.to_bytes(1, byteorder='big')
+        if color is not None:
+            args += self.convert_color(color)
         else:
-            args = []
-            args += time.to_bytes(1, byteorder='big')
-            args += mode.to_bytes(1, byteorder='big')
-            args += sleep_value.to_bytes(1, byteorder='big')
-            args += b'\x00\x00'  # nil FM frequency values
-            args += volume.to_bytes(1, byteorder='big')
-            if color is not None:
-                args += self.convert_color(color)
-            else:
-                args += self.convert_color((0, 0, 0))
-            args += brightness.to_bytes(1, byteorder='big')
+            args += self.convert_color((0, 0, 0))
+        args += brightness.to_bytes(1, byteorder='big')
 
-            result = self.send_command("set sleeptime", args)
+        result = self.send_command("set sleeptime", args)
 
-            return result
+        return result
 

--- a/custom_components/divoom/devices/divoom.py
+++ b/custom_components/divoom/devices/divoom.py
@@ -29,7 +29,8 @@ class Divoom:
         "set brightness": 0x74,
         "set game keypress": 0x88,
         "set game": 0xa0,
-        "set design": 0xbd
+        "set design": 0xbd,
+        "set sleep": 0xa3,
     }
 
     logger = None
@@ -679,3 +680,17 @@ class Divoom:
         """Quickly read most input from Divoom device and remove from buffer. """
         while self.receive(512) == 512:
             self.drop_message_buffer()
+
+    def sleep(self, value=None, mode=None, volume=None):
+        """Set sleep mode on the Divoom device and optionally sets mode and volume"""
+        if mode is None: mode = 0
+        if volume is None: volume = 100
+        sleep_value = 0x01 if value else 0x00
+
+        args = []
+        args += sleep_value.to_bytes(1, byteorder='big')
+        args += mode.to_bytes(1, byteorder='big')
+        args += volume.to_bytes(1, byteorder='big')
+
+        result = self.send_command("set sleep", args)
+        return result

--- a/custom_components/divoom/notify.py
+++ b/custom_components/divoom/notify.py
@@ -37,7 +37,9 @@ PARAM_FREQUENCY = 'frequency'
 PARAM_NUMBER = 'number'
 PARAM_WEEKDAY = 'weekday'
 PARAM_VOLUME = 'volume'
+
 PARAM_SLEEPMODE = 'sleepmode'
+PARAM_SLEEPTIME = 'sleeptime'
 
 PARAM_PLAYER1 = 'player1'
 PARAM_PLAYER2 = 'player2'
@@ -357,7 +359,11 @@ class DivoomNotificationService(BaseNotificationService):
             value = data.get(PARAM_VALUE)
             mode = data.get(PARAM_SLEEPMODE)
             volume = data.get(PARAM_VOLUME)
-            self._device.sleep(value=value, mode=mode, volume=volume)
+            time = data.get(PARAM_SLEEPTIME)
+            color = data.get(PARAM_COLOR)
+            brightness = data.get(PARAM_BRIGHTNESS)
+
+            self._device.sleep(value=value, mode=mode, volume=volume, time=time, color=color, brightness=brightness)
 
         else:
             _LOGGER.error("Invalid mode '{0}', must be one of 'on', 'off', 'connect', 'disconnect', 'clock', 'light', 'effects', 'visualization', 'scoreboard', 'lyrics', 'design', 'image', 'brightness', 'datetime', 'game', 'gamecontrol', 'keyboard', 'playstate', 'radio', 'volume', 'weather', 'countdown', 'noise', 'timer', 'alarm', 'memorial', 'raw'".format(mode))

--- a/custom_components/divoom/notify.py
+++ b/custom_components/divoom/notify.py
@@ -37,15 +37,48 @@ PARAM_FREQUENCY = 'frequency'
 PARAM_NUMBER = 'number'
 PARAM_WEEKDAY = 'weekday'
 PARAM_VOLUME = 'volume'
+PARAM_SLEEPMODE = 'sleepmode'
 
 PARAM_PLAYER1 = 'player1'
 PARAM_PLAYER2 = 'player2'
 
 PARAM_FILE = 'file'
 
+PARAM_SCENE = 1,
+
 PARAM_RAW = 'raw'
 
-VALID_MODES = {'on', 'off', 'connect', 'disconnect', 'clock', 'light', 'effects', 'visualization', 'scoreboard', 'lyrics', 'design', 'image', 'brightness', 'datetime', 'game', 'gamecontrol', 'keyboard', 'playstate', 'radio', 'volume', 'weather', 'countdown', 'noise', 'timer', 'alarm', 'memorial', 'raw'}
+VALID_MODES = {
+    'alarm',
+    'brightness',
+    'clock',
+    'connect',
+    'countdown',
+    'datetime',
+    'design',
+    'disconnect',
+    'effects',
+    'game',
+    'gamecontrol',
+    'image',
+    'keyboard',
+    'light',
+    'lyrics',
+    'memorial',
+    'noise',
+    'off',
+    'on',
+    'playstate',
+    'radio',
+    'raw',
+    'scoreboard',
+    'sleep',
+    'timer',
+    'visualization',
+    'volume',
+    'weather',
+}
+
 WEATHER_MODES = {
     'clear-night': 1, 
     'cloudy': 3, 
@@ -319,6 +352,12 @@ class DivoomNotificationService(BaseNotificationService):
         elif mode == "raw":
             raw = data.get(PARAM_RAW)
             self._device.send_command(command=raw[0], args=raw[1:])
+
+        elif mode == "sleep":
+            value = data.get(PARAM_VALUE)
+            mode = data.get(PARAM_SLEEPMODE)
+            volume = data.get(PARAM_VOLUME)
+            self._device.sleep(value=value, mode=mode, volume=volume)
 
         else:
             _LOGGER.error("Invalid mode '{0}', must be one of 'on', 'off', 'connect', 'disconnect', 'clock', 'light', 'effects', 'visualization', 'scoreboard', 'lyrics', 'design', 'image', 'brightness', 'datetime', 'game', 'gamecontrol', 'keyboard', 'playstate', 'radio', 'volume', 'weather', 'countdown', 'noise', 'timer', 'alarm', 'memorial', 'raw'".format(mode))

--- a/custom_components/divoom/notify.py
+++ b/custom_components/divoom/notify.py
@@ -354,14 +354,16 @@ class DivoomNotificationService(BaseNotificationService):
             self._device.send_command(command=raw[0], args=raw[1:])
 
         elif mode == "sleep":
-            value = data.get(PARAM_VALUE)
-            mode = data.get(PARAM_SLEEPMODE)
-            volume = data.get(PARAM_VOLUME)
-            time = data.get(PARAM_SLEEPTIME)
-            color = data.get(PARAM_COLOR)
-            brightness = data.get(PARAM_BRIGHTNESS)
-
-            self._device.sleep(value=value, mode=mode, volume=volume, time=time, color=color, brightness=brightness)
+            params = {
+                'value': data.get(PARAM_VALUE),
+                'mode': data.get(PARAM_SLEEPMODE),
+                'volume': data.get(PARAM_VOLUME),
+                'time': data.get(PARAM_SLEEPTIME),
+                'color': data.get(PARAM_COLOR),
+                'brightness': data.get(PARAM_BRIGHTNESS),
+                'frequency': data.get(PARAM_FREQUENCY)
+            }
+            self._device.sleep(params)
 
         else:
             _LOGGER.error("Invalid mode '{0}', must be one of 'on', 'off', 'connect', 'disconnect', 'clock', 'light', 'effects', 'visualization', 'scoreboard', 'lyrics', 'design', 'image', 'brightness', 'datetime', 'game', 'gamecontrol', 'keyboard', 'playstate', 'radio', 'volume', 'weather', 'countdown', 'noise', 'timer', 'alarm', 'memorial', 'raw'".format(mode))

--- a/custom_components/divoom/notify.py
+++ b/custom_components/divoom/notify.py
@@ -39,7 +39,7 @@ PARAM_WEEKDAY = 'weekday'
 PARAM_VOLUME = 'volume'
 
 PARAM_SLEEPMODE = 'sleepmode'
-PARAM_SLEEPTIME = 'sleeptime'
+PARAM_SLEEPTIME = 'time'
 
 PARAM_PLAYER1 = 'player1'
 PARAM_PLAYER2 = 'player2'

--- a/custom_components/divoom/notify.py
+++ b/custom_components/divoom/notify.py
@@ -46,8 +46,6 @@ PARAM_PLAYER2 = 'player2'
 
 PARAM_FILE = 'file'
 
-PARAM_SCENE = 1,
-
 PARAM_RAW = 'raw'
 
 VALID_MODES = {


### PR DESCRIPTION
Thanks so much for your work on this. So far, it's working great. I was missing options for the "sleep" function though, which plays soothing sounds like a river, rain etc. for a set period of time.

This PR adds the two commands "[set sleep auto off](https://docin.divoom-gz.com/web/#/5/276)" and "[set sleepscene listen](https://docin.divoom-gz.com/web/#/5/272)". 

The difference between the two, is that "sleep auto off" shows a "sleep light" and switches off after the set timeout.

I have no idea what devices support this, or don't, so I added this in the generic Divoom class. So far so good on my Timebox Evo.