### PR TITLE
Corrected equalizer command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,9 +367,10 @@ Starts the music equalizer.
 | `streammode`      | Actives or deactivates the streaming audio mode with `0` or `1`. |
 
 ```
-message: 'effects'
+message: 'equalizer'
 data:
   number: 2
+  audiomode: 1
 ```
 
 #### MODE game


### PR DESCRIPTION
I noticed a mistake in the docs of the equalizer command, it was accidentally set to affects and didn't have an example with the optional attributes in it.