### PR TITLE
Fix: Deprecation in connection with ZeroconfServiceInfo

### DIFF
--- a/custom_components/divoom/config_flow.py
+++ b/custom_components/divoom/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.bluetooth import (
     async_discovered_service_info,
 )
 
-from homeassistant.components.zeroconf import (
+from homeassistant.helpers.service_info.zeroconf import (
     ZeroconfServiceInfo,
 )
 


### PR DESCRIPTION
Fixes deprecation warning since Home Assistant 2025.x.:
```
Logger: homeassistant.components.zeroconf
Quelle: helpers/deprecation.py:222
Integration: Zero-configuration networking (zeroconf) (Dokumentation, Probleme)
Erstmals aufgetreten: 9. Mai 2025 um 20:27:51 (2 Vorkommnisse)
Zuletzt protokolliert: 9. Mai 2025 um 20:27:51

ZeroconfServiceInfo was used from divoom, this is a deprecated constant which will be removed in HA Core 2026.2. Use homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo instead, please report it to the author of the 'divoom' custom integration
```
Reference:
https://developers.home-assistant.io/blog/2025/01/15/service-info/